### PR TITLE
New Attributes Collector and Status Collector bugfix.

### DIFF
--- a/Attributes.go
+++ b/Attributes.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type Attributes struct {
+	CurrentStatus *CurrentStatus
+}
+
+func NewAttributesFor(currentStatus *CurrentStatus) *Attributes {
+	return &Attributes{
+		CurrentStatus: currentStatus,
+	}
+}
+
+func (instance *Attributes) Describe(ch chan<- *prometheus.Desc) {
+	ch <- instance.Desc()
+}
+
+func (instance *Attributes) Desc() *prometheus.Desc {
+	return prometheus.NewDesc(
+		fmt.Sprintf("%s_monitor_attribute", namespace),
+		"Attributes of the target monitor",
+		[]string{},
+		prometheus.Labels{},
+	)
+}
+
+func (instance *Attributes) Collect(ch chan<- prometheus.Metric) {
+	for _, monitor := range (*instance).CurrentStatus.Data.Monitors {
+		element := &AttributesElement{
+			Parent:  instance,
+			Monitor: monitor,
+		}
+		ch <- element
+	}
+	for _, monitorGroup := range (*instance).CurrentStatus.Data.MonitorGroups {
+		for _, monitor := range monitorGroup.Monitors {
+			element := &AttributesElement{
+				Parent:       instance,
+				MonitorGroup: monitorGroup,
+				Monitor:      monitor,
+			}
+			ch <- element
+		}
+	}
+}
+
+type AttributesElement struct {
+	Parent       *Attributes
+	MonitorGroup CurrentStatusMonitorGroup
+	Monitor      CurrentStatusMonitor
+}
+
+func (instance *AttributesElement) Write(out *dto.Metric) error {
+	out.Gauge = &dto.Gauge{Value: proto.Float64(float64(instance.Monitor.AttributeValue))}
+	label := []*dto.LabelPair{
+		labelPairFor("attributeKey", instance.Monitor.AttributeKey),
+		labelPairFor("monitorId", instance.Monitor.Id),
+		labelPairFor("monitorDisplayName", instance.Monitor.Name),
+		labelPairFor("monitorGroupId", instance.MonitorGroup.Id),
+		labelPairFor("monitorGroupDisplayName", instance.MonitorGroup.Name),
+	}
+	out.Label = label
+	return nil
+}
+
+func (instance *AttributesElement) Desc() *prometheus.Desc {
+	return instance.Parent.Desc()
+}

--- a/Attributes.go
+++ b/Attributes.go
@@ -57,7 +57,15 @@ type AttributesElement struct {
 }
 
 func (instance *AttributesElement) Write(out *dto.Metric) error {
-	out.Gauge = &dto.Gauge{Value: proto.Float64(float64(instance.Monitor.AttributeValue))}
+	var attrValue, err = instance.Monitor.AttributeValue()
+	// Eat the error by setting |attrValue| to something invalid. We don't want
+	// a '-' entry to prevent collecting other metrics, and we must write
+	// something to |out| in this pass.
+	if err != nil {
+		attrValue = -1
+	}
+
+	out.Gauge = &dto.Gauge{Value: proto.Float64(float64(attrValue))}
 	label := []*dto.LabelPair{
 		labelPairFor("attributeKey", instance.Monitor.AttributeKey),
 		labelPairFor("monitorId", instance.Monitor.Id),

--- a/CurrentStatus.go
+++ b/CurrentStatus.go
@@ -1,5 +1,18 @@
 package main
 
+import (
+	"encoding/json"
+	"errors"
+)
+
+var (
+	// String value returned by current_status API to indicate 'no value'.
+	dashValue = `"-"`
+
+	// Error value returned by AttributeValue() in case |dashValue| is observed.
+	errUndefined = errors.New("no metric value")
+)
+
 type CurrentStatus struct {
 	Code      int               `json:"code"`
 	ErrorCode int               `json:"error_code"`
@@ -20,16 +33,28 @@ type CurrentStatusMonitorGroup struct {
 }
 
 type CurrentStatusMonitor struct {
-	Id             string                  `json:"monitor_id"`
-	Name           string                  `json:"name"`
-	Type           string                  `json:"monitor_type"`
-	Status         int                     `json:"status"`
-	AttributeKey   string                  `json:"attribute_key"`
-	AttributeValue int                     `json:"attribute_value"`
-	Locations      []CurrentStatusLocation `json:"locations"`
+	Id                string                  `json:"monitor_id"`
+	Name              string                  `json:"name"`
+	Type              string                  `json:"monitor_type"`
+	Status            int                     `json:"status"`
+	AttributeKey      string                  `json:"attribute_key"`
+	RawAttributeValue json.RawMessage         `json:"attribute_value"`
+	Locations         []CurrentStatusLocation `json:"locations"`
 }
 
 type CurrentStatusLocation struct {
 	Name   string `json:"location_name"`
 	Status int    `json:"status"`
+}
+
+// If the raw |AttributeValue| equals the empty "-", coerce to -1.
+// Otherwise unmarshal as an integer.
+func (csm CurrentStatusMonitor) AttributeValue() (int, error) {
+	if string(csm.RawAttributeValue) == dashValue {
+		return 0, errUndefined
+	} else {
+		var i int
+		var err = json.Unmarshal(csm.RawAttributeValue, &i)
+		return i, err
+	}
 }

--- a/CurrentStatus.go
+++ b/CurrentStatus.go
@@ -1,33 +1,35 @@
 package main
 
 type CurrentStatus struct {
-	Code int `json:"code"`
-	ErrorCode int `json:"error_code"`
-	Message string `json:"message"`
-	Data CurrentStatusData `json:"data"`
+	Code      int               `json:"code"`
+	ErrorCode int               `json:"error_code"`
+	Message   string            `json:"message"`
+	Data      CurrentStatusData `json:"data"`
 }
 
 type CurrentStatusData struct {
-	Monitors []CurrentStatusMonitor `json:"monitors"`
+	Monitors      []CurrentStatusMonitor      `json:"monitors"`
 	MonitorGroups []CurrentStatusMonitorGroup `json:"monitor_groups"`
 }
 
 type CurrentStatusMonitorGroup struct {
-	Id string `json:"group_id"`
-	Name string `json:"group_name"`
-	Status int `json:"status"`
+	Id       string                 `json:"group_id"`
+	Name     string                 `json:"group_name"`
+	Status   int                    `json:"status"`
 	Monitors []CurrentStatusMonitor `json:"monitors"`
 }
 
 type CurrentStatusMonitor struct {
-	Id string `json:"monitor_id"`
-	Name string `json:"name"`
-	Type string `json:"monitor_type"`
-	Status int `json:"status"`
-	Locations []CurrentStatusLocation `json:"locations"`
+	Id             string                  `json:"monitor_id"`
+	Name           string                  `json:"name"`
+	Type           string                  `json:"monitor_type"`
+	Status         int                     `json:"status"`
+	AttributeKey   string                  `json:"attribute_key"`
+	AttributeValue int                     `json:"attribute_value"`
+	Locations      []CurrentStatusLocation `json:"locations"`
 }
 
 type CurrentStatusLocation struct {
-	Name string `json:"location_name"`
-	Status int `json:"status"`
+	Name   string `json:"location_name"`
+	Status int    `json:"status"`
 }

--- a/Status.go
+++ b/Status.go
@@ -8,12 +8,12 @@ import (
 )
 
 type Status struct {
-	CurrentStatus  *CurrentStatus
+	CurrentStatus *CurrentStatus
 }
 
 func NewStatusFor(currentStatus *CurrentStatus) *Status {
 	return &Status{
-		CurrentStatus:  currentStatus,
+		CurrentStatus: currentStatus,
 	}
 }
 
@@ -33,7 +33,7 @@ func (instance *Status) Desc() *prometheus.Desc {
 func (instance *Status) Collect(ch chan<- prometheus.Metric) {
 	for _, monitor := range (*instance).CurrentStatus.Data.Monitors {
 		element := &StatusElement{
-			Parent: instance,
+			Parent:  instance,
 			Monitor: monitor,
 		}
 		ch <- element
@@ -41,9 +41,9 @@ func (instance *Status) Collect(ch chan<- prometheus.Metric) {
 	for _, monitorGroup := range (*instance).CurrentStatus.Data.MonitorGroups {
 		for _, monitor := range monitorGroup.Monitors {
 			element := &StatusElement{
-				Parent: instance,
+				Parent:       instance,
 				MonitorGroup: monitorGroup,
-				Monitor: monitor,
+				Monitor:      monitor,
 			}
 			ch <- element
 		}
@@ -57,16 +57,12 @@ type StatusElement struct {
 }
 
 func (instance *StatusElement) Write(out *dto.Metric) error {
-	out.Counter = &dto.Counter{Value: proto.Float64(float64(instance.Monitor.Status))}
+	out.Gauge = &dto.Gauge{Value: proto.Float64(float64(instance.Monitor.Status))}
 	label := []*dto.LabelPair{
 		labelPairFor("monitorId", instance.Monitor.Id),
 		labelPairFor("monitorDisplayName", instance.Monitor.Name),
-	}
-	if instance.MonitorGroup.Id != "" {
-		label = append(label,
-			labelPairFor("monitorGroupId", instance.MonitorGroup.Id),
-			labelPairFor("monitorGroupDisplayName", instance.MonitorGroup.Name),
-		)
+		labelPairFor("monitorGroupId", instance.MonitorGroup.Id),
+		labelPairFor("monitorGroupDisplayName", instance.MonitorGroup.Name),
 	}
 	out.Label = label
 	return nil


### PR DESCRIPTION
- Add new Attributes collector, which reports on numerical attribute values attached to monitors.
- Repair Status collector, which with the new Prometheus client library must always return the same labels for any metric instance, even if that label is blank.